### PR TITLE
Fix out-of-range file descriptor error in `getdents` syscall

### DIFF
--- a/src/fdtables/dashmapvecglobal.rs
+++ b/src/fdtables/dashmapvecglobal.rs
@@ -85,7 +85,7 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry,
     // always have a table for each cage because each new cage is added at fork
     // time
     assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
-    // Below funtion checks if the virtualfd is out of bounds and if yes it throws an error
+    // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
     if virtualfd >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADFD as u64);
     }

--- a/src/fdtables/dashmapvecglobal.rs
+++ b/src/fdtables/dashmapvecglobal.rs
@@ -86,6 +86,7 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry,
     // time
     assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
     // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
     if virtualfd >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADFD as u64);
     }

--- a/src/fdtables/dashmapvecglobal.rs
+++ b/src/fdtables/dashmapvecglobal.rs
@@ -85,6 +85,10 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry,
     // always have a table for each cage because each new cage is added at fork
     // time
     assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    // Below funtion checks if the virtualfd is out of bounds and if yes it throws an error
+    if virtualfd >= FD_PER_PROCESS_MAX {
+        return Err(threei::Errno::EBADFD as u64);
+    }
 
     return match FDTABLE.get(&cageid).unwrap()[virtualfd as usize] {
         Some(tableentry) => Ok(tableentry),


### PR DESCRIPTION
Fixes # (issue)

<!-- Please include a summary of the changes and the related issue. --> 
This PR addresses an issue in the `getdents` syscall where out-of-range file descriptors (beyond `FD_PER_PROCESS_MAX`) were not handled correctly, leading to index out-of-bounds errors. A bounds check has been added to `translate_virtual_fd` to ensure that file descriptors beyond the allowed range return an `EBADFD` error instead of panicking.

<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
This change prevents potential crashes and ensures that the system handles file descriptor limits gracefully.

<!-- List any dependencies that are required for this change. -->
There are no new dependencies required for this change.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
The changes have been tested by running the `ut_lind_fs_getdents_out_of_range_fd` test, which verifies that the system now correctly returns an error for file descriptors out of range.

<!-- Provide instructions so we can reproduce. -->
- Run the test case: `RUST_BACKTRACE=full cargo test tests::fs_tests::fs_tests::ut_lind_fs_getdents_out_of_range_fd`
- Observe that the error handling for out-of-range file descriptors is now functioning correctly.

<!-- Please also list any relevant details for your test configuration -->
Tested on the following environment:
- Docker container with Linux-based system.

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)

