### PR TITLE
Fix ut lind fs mkdir nonexisting directory

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -18,6 +18,7 @@ use crate::safeposix::filesystem::normpath;
 use crate::safeposix::shm::*;
 use crate::interface::ShmidsStruct;
 use crate::interface::StatData;
+use crate::interface::{CLIPPED_DIRENT_SIZE, ClippedDirent};
 
 use libc::*;
 use std::io::stdout;
@@ -34,6 +35,8 @@ static LIND_ROOT: &str = "/home/lind/lind_project/src/safeposix-rust/tmp";
 
 const FDKIND_KERNEL: u32 = 0;
 const FDKIND_IMPIPE: u32 = 1;
+const S_FILETYPEFLAGS: i32 = 0o170000;
+const S_IFDIR: i32 = 0o40000;
 
 impl Cage {
     //------------------------------------OPEN SYSCALL------------------------------------
@@ -859,6 +862,98 @@ impl Cage {
         }
         
     }
+
+    //------------------IS_DIR FUNCTION------------------
+    /*
+    *   is_dir() checks whether the file mode represents a directory.
+    *   
+    *   This function compares the file mode against the directory bit flag
+    *   (S_IFDIR) and returns whether it is a directory.
+    */
+    pub fn is_dir(mode: u32) -> bool {
+        (mode as i32 & S_FILETYPEFLAGS) == S_IFDIR
+    }
+    
+    //------------------VISIT_CHILDREN FUNCTION------------------
+    /*
+    *   Iterates over all child entries of a directory, applying a visitor function.
+    *   Useful for recursive operations on directory trees.
+    */
+    pub fn visit_children(
+        cage: &Cage,
+        path: &str,
+        arg: Option<usize>,
+        visitor: fn(&Cage, &str, bool, Option<usize>),
+    ) {
+        let mut bigbuffer = [0u8; 65536];
+        let dentptr = bigbuffer.as_mut_ptr();
+    
+        let dirfd = cage.open_syscall(path, O_RDONLY, 0);
+        assert!(dirfd >= 0, "Failed to open directory: {}", path);
+    
+        loop {
+            let direntres = cage.getdents_syscall(dirfd, dentptr, 65536);
+            if direntres == 0 {
+                break;
+            }
+    
+            let mut dentptrindex = 0isize;
+            while dentptrindex < direntres as isize {
+                let clipped_dirent_ptr = dentptr.wrapping_offset(dentptrindex) as *mut ClippedDirent;
+                let clipped_dirent = unsafe { &*clipped_dirent_ptr };
+                let cstrptr = dentptr.wrapping_offset(dentptrindex + CLIPPED_DIRENT_SIZE as isize);
+                let filenamecstr = unsafe { CStr::from_ptr(cstrptr as *const c_char) };
+                let filenamestr = filenamecstr.to_str().unwrap();
+    
+                dentptrindex += clipped_dirent.d_reclen as isize;
+                if filenamestr == "." || filenamestr == ".." {
+                    continue;
+                }
+    
+                let fullstatpath = if path.ends_with("/") {
+                    [path, filenamestr].join("")
+                } else {
+                    [path, "/", filenamestr].join("")
+                };
+    
+                let mut lindstat_res: StatData = StatData::default();
+                let _stat_us = cage.stat_syscall(fullstatpath.as_str(), &mut lindstat_res);
+                visitor(cage, fullstatpath.as_str(), Self::is_dir(lindstat_res.st_mode), arg);
+            }
+        }
+        cage.close_syscall(dirfd);
+    }
+    
+    //------------------LIND_DELTREE FUNCTION------------------
+    /*
+    *   Recursively deletes a directory and all its contents.
+    *   Removes files first, then directories, ensuring they are empty before removal.
+    */
+    pub fn rmdir_recursive_syscall(cage: &Cage, path: &str) -> i32 {
+        let mut lindstat_res: StatData = StatData::default();
+        let stat_us = cage.stat_syscall(path, &mut lindstat_res);
+    
+        if stat_us == 0 {
+            if Self::is_dir(lindstat_res.st_mode) {
+                Self::visit_children(cage, path, None, |childcage, childpath, isdir, _| {
+                    if isdir {
+                        Self::rmdir_recursive_syscall(childcage, childpath);
+                    } else {
+                        let _ = childcage.unlink_syscall(childpath);
+                    }
+                });
+    
+                cage.chmod_syscall(path, S_IRWXA);
+                return cage.rmdir_syscall(path);
+            } else {
+                return cage.unlink_syscall(path);
+            }
+        } else {
+            eprintln!("No such directory exists: {}", path);
+            return syscall_error(Errno::ENOENT, "deltree", "No such directory exists");
+        }
+    }
+    
 
     //------------------RENAME SYSCALL------------------
     /*

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -3047,6 +3047,10 @@ pub mod fs_tests {
 
         let cage = interface::cagetable_getref(1);
         let path = "/parentdir/dir";
+         // Ensure the directories do not exist for clean environment setup
+        let _ = cage.rmdir_syscall("/parentdir/dir");
+        let _ = cage.rmdir_syscall("/parentdir");
+
         // Check for error when both parent and child directories don't exist
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), -(Errno::ENOENT as i32));
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -15,7 +15,6 @@ pub mod fs_tests {
     use crate::interface::ShmidsStruct;
     pub use std::ffi::CStr as RustCStr;
     use std::mem;
-    use crate::tests::Cage;
     use crate::fdtables::FDTABLE;
 
     #[test]
@@ -3047,8 +3046,10 @@ pub mod fs_tests {
 
         let cage = interface::cagetable_getref(1);
         let path = "/parentdir/dir";
-         // Ensure the directories do not exist for clean environment setup
-        let _ = Cage::rmdir_recursive_syscall(&cage, "/parentdir");
+        // Ensure the directories do not exist for clean environment setup
+        // BUG: this rmdir needs to be recursive, we'll change this after we PR a new version of the lindfs tool
+        let _ = cage.rmdir_syscall("/parentdir/dir");
+        let _ = cage.rmdir_syscall("/parentdir");
         // Check for error when both parent and child directories don't exist
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), -(Errno::ENOENT as i32));
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -15,7 +15,7 @@ pub mod fs_tests {
     use crate::interface::ShmidsStruct;
     pub use std::ffi::CStr as RustCStr;
     use std::mem;
-
+    use crate::tests::Cage;
     use crate::fdtables::FDTABLE;
 
     #[test]
@@ -3048,9 +3048,7 @@ pub mod fs_tests {
         let cage = interface::cagetable_getref(1);
         let path = "/parentdir/dir";
          // Ensure the directories do not exist for clean environment setup
-        let _ = cage.rmdir_syscall("/parentdir/dir");
-        let _ = cage.rmdir_syscall("/parentdir");
-
+        let _ = Cage::rmdir_recursive_syscall(&cage, "/parentdir");
         // Check for error when both parent and child directories don't exist
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), -(Errno::ENOENT as i32));
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -3048,6 +3048,7 @@ pub mod fs_tests {
         let path = "/parentdir/dir";
         // Ensure the directories do not exist for clean environment setup
         // BUG: this rmdir needs to be recursive, we'll change this after we PR a new version of the lindfs tool
+        // Clear the directory if it exists use _ to ignore the return value
         let _ = cage.rmdir_syscall("/parentdir/dir");
         let _ = cage.rmdir_syscall("/parentdir");
         // Check for error when both parent and child directories don't exist


### PR DESCRIPTION
Fixes # (issue)

This PR addresses an issue where creating a child directory without an existing parent directory was not handled correctly. The function `mkdir_syscall` is tested to verify that it correctly returns `ENOENT` when attempting to create a directory in a non-existing parent directory. The test cleans up any existing directories beforehand and checks for the expected error when both the parent and child directories are missing.

### Motivation and Context:
The fix ensures that `mkdir_syscall` behaves as expected in cases where a parent directory does not exist. This prevents unexpected directory creations and ensures the proper error handling (returning `ENOENT`) when trying to create a child directory in a non-existent path.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `cargo test tests::fs_tests::fs_tests::ut_lind_fs_mkdir_nonexisting_directory`
The test case `ut_lind_fs_mkdir_nonexisting_directory` was added to validate that `mkdir_syscall` returns `ENOENT` when the parent directory does not exist.

- Test A - `ut_lind_fs_mkdir_nonexisting_directory` verifies the correct behavior of `mkdir_syscall` when both parent and child directories do not exist.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)