### PR TITLE
Fix Test `ut_lind_fs_pread_from_directory` from Directory to Return Correct Error

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -3763,8 +3763,11 @@ pub mod fs_tests {
 
         // Test for invalid directory should fail
         let path = "/test_dir";
+        // NOTE: Use deltree to remove the directory and its contents
+        let _ = cage.rmdir_syscall(path);
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), 0);
-        let fd = cage.open_syscall(path, O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
+        // Open the directory with O_RDONLY (appropriate for directories)
+        let fd = cage.open_syscall(path, O_RDONLY, S_IRWXA);
         assert!(fd >= 0);
         assert_eq!(
             cage.pread_syscall(fd, buf.as_mut_ptr(), buf.len(), 0),

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -3763,8 +3763,6 @@ pub mod fs_tests {
 
         // Test for invalid directory should fail
         let path = "/test_dir";
-        // NOTE: Use deltree to remove the directory and its contents
-        let _ = cage.rmdir_syscall(path);
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), 0);
         // Open the directory with O_RDONLY (appropriate for directories)
         let fd = cage.open_syscall(path, O_RDONLY, S_IRWXA);
@@ -3773,6 +3771,8 @@ pub mod fs_tests {
             cage.pread_syscall(fd, buf.as_mut_ptr(), buf.len(), 0),
             -(Errno::EISDIR as i32)
         );
+        // Clean up the directory for clean environment
+        assert_eq!(cage.rmdir_syscall(path), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
Fixes # (issue)

This change addresses an issue in the test case `ut_lind_fs_pread_from_directory`, where opening a directory with file-related flags caused a failure. The test has been updated to open the directory with `O_RDONLY` (read-only) instead, which is appropriate for directories. The update ensures that the test behaves as expected and returns the correct error (`EISDIR`) when attempting to read from a directory.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo test ut_lind_fs_pread_from_directory`

The updated test case was run to verify that the correct error handling occurs when attempting to pread from a directory. The test now successfully opens the directory with `O_RDONLY` and checks for `EISDIR`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)