### PR TITLE
Fix `ut_lind_fs_rmdir_nowriteperm_parent_dir` rmdir Nowrite Permission Handling and Recursive Directory Cleanup

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2222,9 +2222,6 @@ pub mod fs_tests {
         //'/parent_dir/dir` with all write permision flags.
         let parent_dir = "/parent_dir_nowriteperm";
         let path = "/parent_dir_nowriteperm/dir";
-        // Recursively delete the parent directory if it exists to ensure a clean environment
-        // Note use recursive syscall to delete the parent directory
-        // let _ = Cage::rmdir_recursive_syscall(&cage, parent_dir);
         assert_eq!(cage.mkdir_syscall(parent_dir, S_IRWXA), 0);
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), 0);
         //Now, we change the parent directories write permission flags to 0,
@@ -2237,6 +2234,9 @@ pub mod fs_tests {
 
         // Restore write permissions to the parent to clean up
         assert_eq!(cage.chmod_syscall(parent_dir, S_IRWXA), 0);
+        // Clean up
+        assert_eq!(cage.rmdir_syscall(path), 0);
+        assert_eq!(cage.rmdir_syscall(parent_dir), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
Fixes # (issue)

<!-- Please include a summary of the changes and the related issue. -->
This PR resolves issues with the `rmdir` syscall handling for cases where the parent directory lacks write permissions, which previously caused failures in directory cleanup. Additionally, it adds a recursive delete mechanism that ensures proper permission restoration to allow cleanup, avoiding errors when attempting to remove child directories.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
- `cargo test ut_lind_fs_rmdir_nowriteperm_parent_dir`

### Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)