### PR TITLE
Fix EISDIR Error in `ut_lind_fs_getdents_bufsize_too_small` Test by Adjusting Directory Open Flags

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2570,9 +2570,6 @@ pub mod fs_tests {
     fn ut_lind_fs_getdents_bufsize_too_small() {
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
-        // Remove the directory if it exists
-        // NOTE: Use recursive remove dir
-        // let _ = cage.rmdir_syscall("/getdents");
         let bufsize = interface::CLIPPED_DIRENT_SIZE - 1; // Buffer size smaller than CLIPPED_DIRENT_SIZE
         let mut vec = vec![0u8; bufsize as usize];
         let baseptr: *mut u8 = &mut vec[0];
@@ -2592,7 +2589,8 @@ pub mod fs_tests {
 
         // Close the directory
         assert_eq!(cage.close_syscall(fd), 0);
-
+        // Clean up: Remove the directory and finalize the test environment
+        assert_eq!(cage.rmdir_syscall("/getdents"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2570,7 +2570,9 @@ pub mod fs_tests {
     fn ut_lind_fs_getdents_bufsize_too_small() {
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
-
+        // Remove the directory if it exists
+        // NOTE: Use recursive remove dir
+        // let _ = cage.rmdir_syscall("/getdents");
         let bufsize = interface::CLIPPED_DIRENT_SIZE - 1; // Buffer size smaller than CLIPPED_DIRENT_SIZE
         let mut vec = vec![0u8; bufsize as usize];
         let baseptr: *mut u8 = &mut vec[0];
@@ -2578,8 +2580,8 @@ pub mod fs_tests {
         // Create a directory
         assert_eq!(cage.mkdir_syscall("/getdents", S_IRWXA), 0);
 
-        // Open the directory
-        let fd = cage.open_syscall("/getdents", O_RDWR, S_IRWXA);
+        // Open the directory with O_RDONLY (read-only)
+        let fd = cage.open_syscall("/getdents", O_RDONLY, S_IRWXA);
 
         // Attempt to call `getdents_syscall` with a buffer size smaller than
         // CLIPPED_DIRENT_SIZE


### PR DESCRIPTION
Fixes # (issue)

This PR addresses an issue in the `ut_lind_fs_getdents_bufsize_too_small` test where the `open_syscall` was returning an `EISDIR` error due to incorrect flags (`O_RDWR`) being used when opening a directory. The fix replaces `O_RDWR` with `O_RDONLY`, which is the appropriate flag for opening directories in read-only mode.

### Motivation:
The `EISDIR` error was preventing the test from successfully opening the directory. This change allows the test to proceed as expected, testing the `getdents_syscall` with a buffer size smaller than `CLIPPED_DIRENT_SIZE` and validating that it returns `EINVAL`.

### Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested:
The changes have been tested by running the updated test case `ut_lind_fs_getdents_bufsize_too_small` located at `src/tests/fs_tests.rs`. The test now completes successfully, and the result of the `getdents_syscall` matches the expected `EINVAL`.

- `cargo test ut_lind_fs_getdents_bufsize_too_small`

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)