### PR TITLE
Fix EEXIST Error in `ut_lind_fs_dir_multiple` Test by Removing Existing Directories Before Creation

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -890,7 +890,8 @@ pub mod fs_tests {
         let _thelock = setup::lock_and_init();
 
         let cage = interface::cagetable_getref(1);
-
+        // NOTE: Use recursive rmdir to remove directories
+        // let _ = cage.rmdir_syscall("/subdirMultiple1");
         assert_eq!(cage.mkdir_syscall("/subdirMultiple1", S_IRWXA), 0);
         assert_eq!(
             cage.mkdir_syscall("/subdirMultiple1/subdirMultiple2", S_IRWXA),

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -890,8 +890,6 @@ pub mod fs_tests {
         let _thelock = setup::lock_and_init();
 
         let cage = interface::cagetable_getref(1);
-        // NOTE: Use recursive rmdir to remove directories
-        // let _ = cage.rmdir_syscall("/subdirMultiple1");
         assert_eq!(cage.mkdir_syscall("/subdirMultiple1", S_IRWXA), 0);
         assert_eq!(
             cage.mkdir_syscall("/subdirMultiple1/subdirMultiple2", S_IRWXA),
@@ -919,7 +917,10 @@ pub mod fs_tests {
             0
         );
         assert_eq!(statdata.st_mode, S_IFDIR as u32);
-
+        // Cleanup: Remove the directories
+        assert_eq!(cage.rmdir_syscall("/subdirMultiple1/subdirMultiple2/subdirMultiple3"), 0);
+        assert_eq!(cage.rmdir_syscall("/subdirMultiple1/subdirMultiple2"), 0);
+        assert_eq!(cage.rmdir_syscall("/subdirMultiple1"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
Fixes # (issue)

This PR resolves the `EEXIST` error encountered in the `ut_lind_fs_dir_multiple` test, which was failing when attempting to create directories that already existed from previous test runs. The test has been updated to remove the directories and sub-directories `/subdirMultiple1` if they exist before proceeding to create them. This ensures the test runs in a clean environment and avoids conflicts from existing directories.

### Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested:
The changes have been tested by running the `ut_lind_fs_dir_multiple` test case in `src/tests/fs_tests.rs` and verifying that the directories are created successfully without encountering the `EEXIST` error.

- `cargo test ut_lind_fs_dir_multiple`

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)