### PR TITLE
Fix EEXIST Error in `ut_lind_fs_unlink_directory` 

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -1616,14 +1616,13 @@ pub mod fs_tests {
         let cage = interface::cagetable_getref(1);
 
         let path = "/testdirunlink";
-        // Cleanup the directory if it already exists
-        let _ = cage.rmdir_syscall(path);
         // Create the directory
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), 0);
 
         // Expect an error for unlinking a directory
         assert_eq!(cage.unlink_syscall(path), -(Errno::EISDIR as i32));
-
+        // Cleanup the directory to ensure clean environment
+        let _ = cage.rmdir_syscall(path);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -1616,6 +1616,8 @@ pub mod fs_tests {
         let cage = interface::cagetable_getref(1);
 
         let path = "/testdirunlink";
+        // Cleanup the directory if it already exists
+        let _ = cage.rmdir_syscall(path);
         // Create the directory
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), 0);
 


### PR DESCRIPTION
Fixes # (issue)

This PR resolves the `EEXIST` error encountered in the `ut_lind_fs_unlink_directory` test, which was failing when attempting to create directories that already existed from previous test runs. The test has been updated to remove the directories `/testdirunlink` if they exist before proceeding to create them. This ensures the test runs in a clean environment and avoids conflicts from existing directories.

### Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested:
The changes have been tested by running the `ut_lind_fs_unlink_directory` test case in `src/tests/fs_tests.rs` and verifying that the directories are created successfully without encountering the `EEXIST` error.

- `cargo test ut_lind_fs_unlink_directory`

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)