### PR TITLE
Fix in `ut_lind_fs_read_from_directory` for cleanup dir

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -3495,7 +3495,7 @@ pub mod fs_tests {
             cage.read_syscall(fd, read_buf.as_mut_ptr(), 5),
             -(Errno::EISDIR as i32)
         );
-
+        let _ = cage.rmdir_syscall(path);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
Fixes # (issue)

This PR resolves the `EEXIST` error encountered in the `ut_lind_fs_read_from_directory` test, which was failing when attempting to create directories that already existed from previous test runs. The test has been updated to remove the directories `/test_dir` if they exist before proceeding to create them. This ensures the test runs in a clean environment and avoids conflicts from existing directories.

### Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested:
The changes have been tested by running the `ut_lind_fs_read_from_directory` test case in `src/tests/fs_tests.rs` and verifying that the directories are created successfully without encountering the `EEXIST` error.

- `cargo test ut_lind_fs_read_from_directory`

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)