### PR TITLE
fix: getdents folders cleanup

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2512,6 +2512,7 @@ pub mod fs_tests {
         }
 
         assert_eq!(cage.close_syscall(fd), 0);
+        // Clean up environment by removing the directory
         assert_eq!(cage.rmdir_syscall("/getdents"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
@@ -2539,6 +2540,7 @@ pub mod fs_tests {
 
         // Close the directory
         assert_eq!(cage.close_syscall(fd), 0);
+        // Clean up environment by removing the directory
         assert_eq!(cage.rmdir_syscall("/getdents"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2512,6 +2512,7 @@ pub mod fs_tests {
         }
 
         assert_eq!(cage.close_syscall(fd), 0);
+        assert_eq!(cage.rmdir_syscall("/getdents"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }
@@ -2538,7 +2539,7 @@ pub mod fs_tests {
 
         // Close the directory
         assert_eq!(cage.close_syscall(fd), 0);
-
+        assert_eq!(cage.rmdir_syscall("/getdents"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

This PR addresses an issue where directory cleanup was not properly handled in tests involving `getdents_syscall`. To ensure a clean environment between test runs, I have added the following line:

```rust
assert_eq!(cage.rmdir_syscall("/getdents"), 0);
```

This removes the `/getdents` directory after the test case is complete, preventing conflicts or leftover directories from interfering with subsequent tests. Additionally, this ensures that the test environment is consistent and isolated for each test run.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The fix has been verified through existing tests in the following test cases:
`cargo test ut_lind_fs_getdents`
These tests confirm that the addition of the directory cleanup resolves any potential conflicts from leftover files or directories between test runs.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
