### PR TITLE
fix: test case ut_lind_fs_rmdir_normal

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2116,7 +2116,8 @@ pub mod fs_tests {
             cage.open_syscall(path, O_TRUNC, S_IRWXA),
             -(Errno::ENOENT as i32)
         );
-
+        // Clean up the parent directory for clean environment
+        assert_eq!(cage.rmdir_syscall("/parent_dir"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

This PR addresses an issue where directory cleanup was not properly handled in tests involving `ut_lind_fs_rmdir_normal`. To ensure a clean environment between test runs.

This removes the `/parent_dir` directory after the test case is complete, preventing conflicts or leftover directories from interfering with subsequent tests. Additionally, this ensures that the test environment is consistent and isolated for each test run.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The fix has been verified through existing tests in the following test cases:
`cargo test ut_lind_fs_rmdir_normal`
These tests confirm that the addition of the directory cleanup resolves any potential conflicts from leftover files or directories between test runs.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
