### PR TITLE
fix: test case `ut_lind_fs_link_invalid_path_permissions`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -1764,6 +1764,8 @@ pub mod fs_tests {
 
         // Create the directory for the oldpath with the parent not having read
         // permission. Currently assigning "Write only" permissions
+        // Remove the directory if it already exists
+        let _ = cage.rmdir_syscall("/invalidtestdir");
         assert_eq!(cage.mkdir_syscall("/invalidtestdir", 0o200), 0);
         assert_eq!(
             cage.open_syscall(oldpath, O_CREAT | O_EXCL | O_WRONLY, 0o200),
@@ -1777,7 +1779,8 @@ pub mod fs_tests {
             cage.link_syscall(oldpath, newpath),
             -(Errno::EACCES as i32)
         );
-
+        // Cleanup the directory to ensure clean environment
+        assert_eq!(cage.rmdir_syscall("/invalidtestdir"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

Fixes # (issue)

Added a clean-up step to ensure the test environment is always reset before the `mkdir` operation in the `ut_lind_fs_link_invalid_path_permissions` test case. The line `let _ = cage.rmdir_syscall(old_path);` was introduced to remove the directory if it already exists, ensuring a clean environment for testing. This change enhances the reliability of the test by preventing conflicts from pre-existing directories.

<!-- Please include a summary of the changes and the related issue. -->
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `cargo test ut_lind_fs_link_invalid_path_permissions`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
