### PR TITLE
fix: test case `ut_lind_fs_mmap_no_read`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -507,11 +507,14 @@ pub mod fs_tests {
         //Checking if trying to map a file that does not
         //allow reading correctly results in `File descriptor
         //is not open for reading` error.
-        assert_eq!(
-            cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0),
-            -(Errno::EACCES as i32)
-        );
-
+        let mmap_result = cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        assert_eq!(mmap_result, -1, "Expected mmap to fail");
+        // Fetch and print the errno for debugging
+        let error = get_errno();
+        // Assert that the error is EACCES (Permission denied)
+        assert_eq!(error, libc::EACCES, "Expected errno to be EACCES for no read permission");
+        // Clean up and finalize
+        assert_eq!(cage.unlink_syscall(filepath), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

Fixes # (issue)

This PR updates the `ut_lind_fs_mmap_no_read` test to correctly handle the `mmap_syscall` failure case when a file is opened with write-only permissions (`O_WRONLY`) and then an attempt is made to map the file with read permissions (`PROT_READ | PROT_WRITE`). The previous test directly checked the return value of `mmap_syscall`, which was incorrect. System calls typically return `-1` on failure, and the specific error code (`EACCES` in this case) is stored in `errno`.

### Changes:
- Modified the test to check that `mmap_syscall` returns `-1` to indicate failure.
- Added an additional check to ensure that `errno` is set to `EACCES`, which represents "Permission denied" due to the lack of read permissions on the file.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo test ut_lind_fs_mmap_no_read`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
