### PR TITLE
fix: test case `ut_lind_fs_pwrite_to_directory`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -4178,6 +4178,8 @@ pub mod fs_tests {
         // We should expect an error (EISDIR) as writing to a directory is not
         // supported.
         let path = "/test_dir";
+        // Remove the directory if it exists to ensure a clean test environment
+        let _ = cage.rmdir_syscall(path);
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), 0);
         // Open the directory with O_RDONLY
         let fd = cage.open_syscall(path, O_RDONLY, S_IRWXA);


### PR DESCRIPTION
## Description

Fixes # (issue)

Added a clean-up step to ensure the test environment is always reset before the `mkdir` operation in the `ut_lind_fs_pwrite_to_directory` test case. The line `let _ = cage.rmdir_syscall('/test_dir');` was introduced to remove the directory if it already exists, ensuring a clean environment for testing. This change enhances the reliability of the test by preventing conflicts from pre-existing directories.

<!-- Please include a summary of the changes and the related issue. -->
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `cargo test ut_lind_fs_pwrite_to_directory`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)