### PR TITLE
fix: test case `ut_lind_fs_rmdir_nowriteperm_child_dir`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2237,14 +2237,18 @@ pub mod fs_tests {
         //because the directory cannot be removed if it does not allow
         //write permission
         let path = "/parent_dir_nwchild/dir";
+        // Remove the directory if it already exists
+        let _ = cage.rmdir_syscall("/parent_dir_nwchild/dir");
+        let _ = cage.rmdir_syscall("/parent_dir_nwchild");
         assert_eq!(cage.mkdir_syscall("/parent_dir_nwchild", S_IRWXA), 0);
         assert_eq!(cage.mkdir_syscall(path, S_IRWXA), 0);
         assert_eq!(
             cage.chmod_syscall(path, 0o400 | 0o040 | 0o004),
             0
         );
+        // Clean up the directories for clean environment
         assert_eq!(cage.rmdir_syscall(path), 0);
-
+        assert_eq!(cage.rmdir_syscall("/parent_dir_nwchild"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

Fixes # (issue)

Added a clean-up step to ensure the test environment is always reset before the `mkdir` operation in the `ut_lind_fs_rmdir_nowriteperm_child_dir` test case. The line cage.rmdir_syscall was introduced to remove the directory if it already exists, ensuring a clean environment for testing. This change enhances the reliability of the test by preventing conflicts from pre-existing directories.

<!-- Please include a summary of the changes and the related issue. -->
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `cargo test ut_lind_fs_rmdir_nowriteperm_child_dir`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
