### PR TITLE
fix: test case `ut_lind_fs_unlink_and_close_file`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -1667,8 +1667,11 @@ pub mod fs_tests {
 
         let cage = interface::cagetable_getref(1);
         let path = "/testfile";
+        // Unlink the file if it exists
+        let _ = cage.unlink_syscall(path);
         // Create a file
         let fd = cage.open_syscall(path, O_CREAT | O_EXCL | O_WRONLY, S_IRWXA);
+        println!("fd: {}", fd);
         let mut statdata = StatData::default();
         assert_eq!(cage.stat_syscall(path, &mut statdata), 0);
         // Linkcount for the file should be 1 originally

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -1671,7 +1671,6 @@ pub mod fs_tests {
         let _ = cage.unlink_syscall(path);
         // Create a file
         let fd = cage.open_syscall(path, O_CREAT | O_EXCL | O_WRONLY, S_IRWXA);
-        println!("fd: {}", fd);
         let mut statdata = StatData::default();
         assert_eq!(cage.stat_syscall(path, &mut statdata), 0);
         // Linkcount for the file should be 1 originally


### PR DESCRIPTION
## Description

Fixes # (issue)

This pull request introduces a test case (`ut_lind_fs_unlink_and_close_file`) that validates the proper unlinking and closing of a regular file. The test ensures that once the file is unlinked and its file descriptor is closed, the file is no longer accessible, and the file descriptor is invalid.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo test ut_lind_fs_unlink_and_close_file`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
