### PR TITLE
fix: test case `ut_lind_fs_stat_file_complex`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2341,6 +2341,8 @@ pub mod fs_tests {
         let _thelock = setup::lock_and_init();
 
         let cage = interface::cagetable_getref(1);
+        // Remove the file if it already exists
+        let _ = cage.unlink_syscall("/fooComplex");
         let fd = cage.open_syscall("/fooComplex", O_CREAT | O_EXCL | O_WRONLY, S_IRWXA);
 
         assert_eq!(cage.write_syscall(fd, str2cbuf("hi"), 2), 2);
@@ -2359,7 +2361,9 @@ pub mod fs_tests {
         //check that they are the same and that the link count is 0
         assert!(statdata == statdata2);
         assert_eq!(statdata.st_nlink, 2);
-
+        // Clean up the file for a clean environment
+        assert_eq!(cage.unlink_syscall("/fooComplex"), 0);
+        assert_eq!(cage.unlink_syscall("/barComplex"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

Fixes # (issue)

This pull request introduces a test case (`ut_lind_fs_stat_file_complex`) that ensures the correct handling of file creation, linking, and unblinking. Added unlink syscalls to remove file prior to test case and after test case is completed.


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo test ut_lind_fs_stat_file_complex`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)