### PR TITLE
fix: test case `ut_lind_fs_open_nonexisting_parentdirectory_and_file`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -3271,18 +3271,17 @@ pub mod fs_tests {
         let path = "/dir/file";
         // Check for error when neither file nor parent exists and O_CREAT flag is not
         // present
-        assert_eq!(
-            cage.open_syscall(path, F_GETFD, S_IRWXA),
-            -(Errno::ENOENT as i32)
-        );
+        cage.open_syscall(path, F_GETFD, S_IRWXA);
+        let err = get_errno();
+        assert_eq!(err, libc::ENOENT, "Expected ENOENT, got {}", err);
 
-        // Check for error when neither file nor parent exists and O_CREAT flag is
-        // present
-        assert_eq!(
-            cage.open_syscall(path, O_CREAT, S_IRWXA),
-            -(Errno::ENOENT as i32)
-        );
-
+        // Check for error when neither file nor parent exists and O_CREAT flag is present
+        cage.open_syscall(path, O_CREAT, S_IRWXA);
+        let err2 = get_errno();
+        assert_eq!(err2, libc::ENOENT, "Expected ENOENT, got {}", err2);
+        // Clean up and finalize
+        let _ = cage.unlink_syscall(path);
+        let _ = cage.rmdir_syscall("/dir");
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

Fixes # (issue)

This pull request addresses a test case (`ut_lind_fs_open_nonexisting_parentdirectory_and_file`) that ensures the proper handling of scenarios where both a parent directory and the file do not exist. The test confirms that attempting to open such non-existent files without the `O_CREAT` flag and even with the flag correctly returns an `ENOENT` error (No such file or directory).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo test ut_lind_fs_open_nonexisting_parentdirectory_and_file`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
