### PR TITLE
fix: test case `ut_lind_fs_mkdir_using_symlink`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -3218,7 +3218,9 @@ pub mod fs_tests {
         let _thelock = setup::lock_and_init();
 
         let cage = interface::cagetable_getref(1);
-
+        // Delete the files if it exists
+        let _ = cage.unlink_syscall("/symlinkFile");
+        let _ = cage.unlink_syscall("/originalFile");
         // Create a file which will be referred to as originalFile
         let fd = cage.open_syscall("/originalFile", O_CREAT | O_EXCL | O_WRONLY, S_IRWXA);
         assert_eq!(cage.write_syscall(fd, str2cbuf("hi"), 2), 2);
@@ -3233,6 +3235,10 @@ pub mod fs_tests {
             cage.mkdir_syscall("/symlinkFile", S_IRWXA),
             -(Errno::EEXIST as i32)
         );
+
+        // Clean up and finalize
+        assert_eq!(cage.unlink_syscall("/symlinkFile"), 0);
+        assert_eq!(cage.unlink_syscall("/originalFile"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

Fixes # (issue)

This pull request introduces a test case (`ut_lind_fs_mkdir_using_symlink`) that ensures the correct handling of file creation, linking, and unblinking. Added unlink syscalls to remove file prior to test case and after test case is completed.


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo test ut_lind_fs_mkdir_using_symlink`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)