### PR TITLE
fix: test case `ut_lind_fs_lseek_beyond_file_size`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -4403,7 +4403,8 @@ pub mod fs_tests {
         let _thelock = setup::lock_and_init();
 
         let cage = interface::cagetable_getref(1);
-
+        // Remove the file if it exists to ensure a clean test environment
+        let _ = cage.unlink_syscall("/test_file");
         // Test to create a file and seek beyond its size
         let fd = cage.open_syscall("/test_file", O_CREAT | O_RDWR, S_IRWXA);
         assert!(fd >= 0);
@@ -4416,7 +4417,8 @@ pub mod fs_tests {
             cage.lseek_syscall(fd, 10, SEEK_END),
             15 // 5 (file size) + 10 (offset)
         );
-
+        // Clean up the file for clean environment
+        assert_eq!(cage.unlink_syscall("/test_file"), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

Fixes # (issue)

This pull request introduces a test case (`ut_lind_fs_lseek_beyond_file_size`) that ensures the correct handling of file creation, linking, and unblinking. Added unlink syscalls to remove file prior to test case and after test case is completed.


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo test ut_lind_fs_lseek_beyond_file_size`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)