### PR TITLE
fix: test case `ut_lind_fs_chmod_valid_args`

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -307,7 +307,6 @@ pub mod fs_tests {
         assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
         assert_eq!(statdata.st_mode, S_IRWXA | S_IFREG as u32);
         // Clean up files and directories
-        let _ = cage.unlink_syscall("../testFolder/chmodTestFile");
         let _ = cage.unlink_syscall(filepath);
         let _ = cage.unlink_syscall("chmodTestFile1");
         let _ = cage.rmdir_syscall(newdir);

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -242,6 +242,12 @@ pub mod fs_tests {
         let filepath = "/chmodTestFile1";
 
         let mut statdata = StatData::default();
+        let newdir = "../testFolder";
+
+        // Remove the file and directory if it exists
+        let _ = cage.unlink_syscall("../testFolder/chmodTestFile");
+        let _ = cage.unlink_syscall(filepath);
+        let _ = cage.rmdir_syscall(newdir);
 
         //checking if the file was successfully created with the specified initial
         // flags set all mode bits to 0 to change them later
@@ -286,7 +292,6 @@ pub mod fs_tests {
 
         //checking if `chmod_syscall()` works with relative path that include parent
         // directory reference
-        let newdir = "../testFolder";
         assert_eq!(cage.mkdir_syscall(newdir, S_IRWXA), 0);
         let filepath = "../testFolder/chmodTestFile";
 
@@ -301,7 +306,11 @@ pub mod fs_tests {
         assert_eq!(cage.chmod_syscall(filepath, S_IRWXA), 0);
         assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
         assert_eq!(statdata.st_mode, S_IRWXA | S_IFREG as u32);
-
+        // Clean up files and directories
+        let _ = cage.unlink_syscall("../testFolder/chmodTestFile");
+        let _ = cage.unlink_syscall(filepath);
+        let _ = cage.unlink_syscall("chmodTestFile1");
+        let _ = cage.rmdir_syscall(newdir);
         assert_eq!(cage.close_syscall(fd), 0);
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();


### PR DESCRIPTION
## Description

Fixes

This PR addresses cleanup and removal operations in the test cases by implementing specific unlink and rmdir syscalls to ensure files and directories are removed correctly. This change is required to enhance test reliability and prevent leftover files/directories that might affect subsequent tests.

### Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- `cargo test ut_lind_fs_chmod_valid_args`

## Checklist:

- [x] Code follows project style guidelines.
- [x] Code is well-commented, especially in complex sections.
- [x] Changes generate no new warnings.
- [x] Tests validate the fix or new feature.
- [x] Dependent changes have been added in relevant modules (native-client, lind-glibc, lind-project).
