### PR TITLE
Fix kernel close and select bug

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1881,7 +1881,7 @@ impl Cage {
     }
 }
 
-pub fn kernel_close(fdentry: fdtables::FDTableEntry) {
+pub fn kernel_close(fdentry: fdtables::FDTableEntry, _count: u64) {
     let _ret = unsafe {
         libc::close(fdentry.underfd as i32)
     };

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1881,8 +1881,8 @@ impl Cage {
     }
 }
 
-pub fn kernel_close(_fdentry: fdtables::FDTableEntry, kernelfd: u64) {
+pub fn kernel_close(fdentry: fdtables::FDTableEntry) {
     let _ret = unsafe {
-        libc::close(kernelfd as i32)
+        libc::close(fdentry.underfd as i32)
     };
 }


### PR DESCRIPTION
## Description

Fixes #48 

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

#### kernel close
The updated fdtable API passing fd entry and count instead of real fd into `kernel_close` function in RawPOSIX, which will cause the actual requested real fd not being closed. Updated code to fit newest API.

#### select
The initial error occurred because cases where each `fd_set` was empty were not handled. In the updated code, uninitialized values are automatically assigned to the corresponding `fd_set`. Additionally, during in-depth debugging, I found that when processing the return value, the `fdtable::` function should receive an `nfd` associated with the kernel file descriptor (i.e., the maximum kernel file descriptor + 1).

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- [socketselect.c](https://github.com/Lind-Project/lind_project/blob/develop/tests/test_cases/socketselect.c)
- [uds-nb-select.c](https://github.com/Lind-Project/lind_project/blob/develop/tests/test_cases/uds-nb-select.c)
- [uds-socketselect.c](https://github.com/Lind-Project/lind_project/blob/develop/tests/test_cases/uds-socketselect.c)

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
